### PR TITLE
docs: Fix a few typos

### DIFF
--- a/app/config/__init__.py
+++ b/app/config/__init__.py
@@ -22,7 +22,7 @@ def set_app_config_keys(app, settings):
 
 
 def development_config(app):
-    """Call the function responsable by load config vars
+    """Call the function responsible by load config vars
     using 'development' settings.
 
     :app: a flask.Flask object
@@ -33,7 +33,7 @@ def development_config(app):
 
 
 def testing_config(app):
-    """Call the function responsable by load config vars
+    """Call the function responsible by load config vars
     using 'testing' settings.
 
     :app: a flask.Flask object
@@ -44,7 +44,7 @@ def testing_config(app):
 
 
 def production_config(app):
-    """Call the function responsable by load config vars
+    """Call the function responsible by load config vars
     using 'production' settings.
 
     :app: a flask.Flask object

--- a/app/helpers.py
+++ b/app/helpers.py
@@ -84,7 +84,7 @@ def standardize_api_response(function):
         deleted -> DELETE, 200
         no-data -> No Content, 204
 
-    :returns: json.dumps(response), staus code
+    :returns: json.dumps(response), status code
     """
 
     available_result_keys = [

--- a/app/users/models.py
+++ b/app/users/models.py
@@ -9,7 +9,7 @@ class User(db.Document):
     password = db.StringField()
 
     def to_json2(self):
-        """Returns a json representantion of the user.
+        """Returns a json representation of the user.
         :returns: a json object.
 
         """

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -29,7 +29,7 @@ def jrequest(method, url, client, headers={}, data=None):
     :headers: Optional headers.
         As default uses Content-Type: application/json
     :data: Optional data for POST or PUT requests
-    :returns: the request reponse.
+    :returns: the request response.
 
     """
 

--- a/tests/mocks/users.py
+++ b/tests/mocks/users.py
@@ -4,7 +4,7 @@ from app import models, helpers
 
 @pytest.yield_fixture(scope='function')
 def mock_user():
-    """Returns a function (clojuse) to createa a mock.
+    """Returns a function (clojuse) to create a mock.
     """
 
     user = None


### PR DESCRIPTION
There are small typos in:
- app/config/__init__.py
- app/helpers.py
- app/users/models.py
- tests/integration/__init__.py
- tests/mocks/users.py

Fixes:
- Should read `responsible` rather than `responsable`.
- Should read `status` rather than `staus`.
- Should read `response` rather than `reponse`.
- Should read `representation` rather than `representantion`.
- Should read `create` rather than `createa`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md